### PR TITLE
Sync fix

### DIFF
--- a/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
+++ b/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
@@ -72,6 +72,11 @@ public class PullRequestListener implements DisposableBean
     @EventListener
     public void createdEvent(PullRequestOpenedEvent event) throws IOException
     {
+        final PullRequest pullRequest = event.getPullRequest();
+        // TODO remove the canMerge call after Bitbucket fixes bug regarding consistent ref update
+        // See the accepted answer why the can merge call helps as workaround:
+        // https://answers.atlassian.com/questions/239988
+        pullRequestService.canMerge(pullRequest.getToRef().getRepository().getId(), pullRequest.getId());
         sendPullRequestEvent(event, EventType.PULL_REQUEST_CREATED);
     }
 


### PR DESCRIPTION
A fix for a Bitbucket/Jenkins synchronisation problem that has arisen since we updated Jenkins.

This is the bare minimum from https://github.com/topicusfinan/bitbucket-webhooks-plugin/pull/51/files that addresses https://github.com/topicusfinan/bitbucket-webhooks-plugin/issues/50